### PR TITLE
Modify Mapbox basemap to streets-satellite

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -189,7 +189,7 @@
     attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
       '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
       'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-    id: 'mapbox.streets'
+    id: 'mapbox.streets-satellite'
   }).addTo(mymap);
 
 </script>


### PR DESCRIPTION
We go from this: 
![image](https://user-images.githubusercontent.com/3285923/49698919-5f767680-fb98-11e8-8702-9279fc808966.png)

to this:
![image](https://user-images.githubusercontent.com/3285923/49698924-6dc49280-fb98-11e8-8636-c77f3b080357.png)

I think it will fit better with the page UI.

